### PR TITLE
Make the code run on Windows.

### DIFF
--- a/pbm.h
+++ b/pbm.h
@@ -47,21 +47,21 @@ ssize_t my_random(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-  // Allocate memory for image data
-  PbmImage *image = (PbmImage *) malloc(sizeof(PbmImage));
-  if (!image) {
-    fprintf(stderr, "Error: out of memory\n");
-    return NULL;
-  }
-  image->width_ = width;
-  image->height_ = height;
-  image->data_ = (uint8_t *) malloc(width * height * sizeof(uint8_t));
-  if (!image->data_) {
-    fprintf(stderr, "Error: out of memory\n");
-    free(image);
-    return NULL;
-  }
-  return image;
+    // Allocate memory for image data
+    PbmImage *image = (PbmImage *) malloc(sizeof(PbmImage));
+    if (!image) {
+        fprintf(stderr, "Error: out of memory\n");
+        return NULL;
+    }
+    image->width_ = width;
+    image->height_ = height;
+    image->data_ = (uint8_t *) malloc(width * height * sizeof(uint8_t));
+    if (!image->data_) {
+        fprintf(stderr, "Error: out of memory\n");
+        free(image);
+        return NULL;
+    }
+    return image;
 }
 
 /**
@@ -71,72 +71,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-  // Open file for reading
-  FILE *fp = fopen(filename, "rb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s'\n", filename);
-    return NULL;
-  }
+    // Open file for reading
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s'\n", filename);
+        return NULL;
+    }
 
-  // Read header (magic number, width, and height)
-  char magic[3];
-  uint32_t width;
-  uint32_t height;
-  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-             &height) != 3) {
-    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
+    // Read header (magic number, width, and height)
+    char magic[3];
+    uint32_t width;
+    uint32_t height;
+    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+               &height) != 3) {
+        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Make sure the magic number is "P4" (binary PBM format)
+    if (magic[0] != 'P' || magic[1] != '4') {
+        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Allocate memory for buffer
+    size_t buffer_size = (size_t) ((width * height + 7) / 8);
+    uint8_t *buffer = (uint8_t *) malloc(buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    // Read pixel data into buffer
+    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Close file
     fclose(fp);
-    return NULL;
-  }
 
-  // Make sure the magic number is "P4" (binary PBM format)
-  if (magic[0] != 'P' || magic[1] != '4') {
-    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Allocate memory for buffer
-  size_t buffer_size = (size_t) ((width * height + 7) / 8);
-  uint8_t *buffer = (uint8_t *) malloc(buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return NULL;
-  }
-
-  // Read pixel data into buffer
-  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-            filename);
-    free(buffer);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Close file
-  fclose(fp);
-
-  // Allocate memory for image data
-  PbmImage *image = AllocatePbm(width, height);
+    // Allocate memory for image data
+    PbmImage *image = AllocatePbm(width, height);
 
 // Decode the pixel data from the buffer
-#pragma omp parallel for default(none) shared(image, buffer, width, height)
-  for (size_t i = 0; i < width * height; i += 8) {
-    // Read the next byte from the buffer
-    uint8_t byte = buffer[i / 8];
+    #pragma omp parallel for default(none) shared(image, buffer, width, height)
+    for (size_t i = 0; i < width * height; i += 8) {
+        // Read the next byte from the buffer
+        uint8_t byte = buffer[i / 8];
 
-    // Decode the byte into the image data (loop through the 8 bits)
-    for (size_t j = 0; j < 8; j++) {
-      size_t index = i + j;
-      if (index < width * height) {
-        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-      }
+        // Decode the byte into the image data (loop through the 8 bits)
+        for (size_t j = 0; j < 8; j++) {
+            size_t index = i + j;
+            if (index < width * height) {
+                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+            }
+        }
     }
-  }
 
-  free(buffer);
-  return image;
+    free(buffer);
+    return image;
 }
 
 /**
@@ -146,12 +146,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-  double *double_data =
-      (double *) malloc(image->width_ * image->height_ * sizeof(double));
-#pragma omp parallel for default(none) shared(image, double_data)
-  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-    double_data[i] = (double) image->data_[i] / PGM_MAX_GRAY_F;
-  return double_data;
+    double *double_data =
+        (double *) malloc(image->width_ * image->height_ * sizeof(double));
+    #pragma omp parallel for default(none) shared(image, double_data)
+    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+        double_data[i] = (double) image->data_[i] / PGM_MAX_GRAY_F;
+    return double_data;
 }
 
 /**
@@ -159,7 +159,9 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() { return 128; }
+uint8_t MiddleThreshold() {
+    return 128;
+}
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -167,9 +169,9 @@ uint8_t MiddleThreshold() { return 128; }
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-  uint8_t random;
+    uint8_t random;
     my_random(&random, sizeof(uint8_t));
-  return random;
+    return random;
 }
 
 /**
@@ -181,15 +183,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
 // Convert pixel data
-#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-    pbm_image->data_[i] = image->data_[i] < threshold();
+    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+        pbm_image->data_[i] = image->data_[i] < threshold();
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -200,55 +202,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Atkinson dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Atkinson dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 1 / 8;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 1 / 8;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -259,23 +261,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
 // Convert using Bayer (Ordered) Dithering
-#pragma omp parallel for default(none)                                         \
+    #pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+        }
     }
-  }
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -286,43 +288,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Floyd-Steinberg dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Floyd-Steinberg dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 16;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 16;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 16;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 16;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -333,61 +335,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Jarvis, Judice, and Ninke dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Jarvis, Judice, and Ninke dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 48;
-      }
-      if (x < pbm_image->width_ - 2) {
-        double_data[pos + 2] += error * 5 / 48;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 48;
+            }
+            if (x < pbm_image->width_ - 2) {
+                double_data[pos + 2] += error * 5 / 48;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -398,47 +400,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-  // Open file for writing
-  FILE *fp = fopen(filename, "wb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-    return false;
-  }
+    // Open file for writing
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+        return false;
+    }
 
-  // Write header (magic number, width, height)
-  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-    fclose(fp);
-    return false;
-  }
+    // Write header (magic number, width, height)
+    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+        fclose(fp);
+        return false;
+    }
 
-  // Allocate buffer for encoded pixel data
-  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-  uint8_t *buffer = (uint8_t *) calloc(1, buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return false;
-  }
+    // Allocate buffer for encoded pixel data
+    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+    uint8_t *buffer = (uint8_t *) calloc(1, buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return false;
+    }
 
 // Encode pixel data
-#pragma omp parallel for default(none) shared(image, buffer)
-  for (size_t i = 0; i < image->width_ * image->height_; i++) {
-    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-  }
+    #pragma omp parallel for default(none) shared(image, buffer)
+    for (size_t i = 0; i < image->width_ * image->height_; i++) {
+        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+    }
 
-  // Write encoded pixel data to file
-  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-            filename);
+    // Write encoded pixel data to file
+    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return false;
+    }
+
     free(buffer);
     fclose(fp);
-    return false;
-  }
-
-  free(buffer);
-  fclose(fp);
-  return true;
+    return true;
 }
 
 /**
@@ -447,8 +449,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-  free(image->data_);
-  free(image);
+    free(image->data_);
+    free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -14,9 +14,7 @@
 
 #include <sys/random.h>
 
-ssize_t MyRandom(void *buf, size_t len) {
-    return getrandom(buf, len, 0);
-}
+ssize_t MyRandom(void *buf, size_t len) { return getrandom(buf, len, 0); }
 
 #else /* not linux */
 
@@ -25,14 +23,14 @@ ssize_t MyRandom(void *buf, size_t len) {
 #include <stdlib.h>
 
 ssize_t MyRandom(void *buf, size_t len) {
-    unsigned char *buffer = (unsigned char *)buf;
-    size_t i;
+  unsigned char *buffer = (unsigned char *)buf;
+  size_t i;
 
-    for (i = 0; i < len; ++i) {
-        buffer[i] = (unsigned char)rand();
-    }
+  for (i = 0; i < len; ++i) {
+    buffer[i] = (unsigned char)rand();
+  }
 
-    return (ssize_t)len;
+  return (ssize_t)len;
 }
 
 #endif
@@ -45,21 +43,21 @@ ssize_t MyRandom(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-    // Allocate memory for image data
-    PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
-    if (!image) {
-        fprintf(stderr, "Error: out of memory\n");
-        return NULL;
-    }
-    image->width_ = width;
-    image->height_ = height;
-    image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
-    if (!image->data_) {
-        fprintf(stderr, "Error: out of memory\n");
-        free(image);
-        return NULL;
-    }
-    return image;
+  // Allocate memory for image data
+  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+  if (!image) {
+    fprintf(stderr, "Error: out of memory\n");
+    return NULL;
+  }
+  image->width_ = width;
+  image->height_ = height;
+  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+  if (!image->data_) {
+    fprintf(stderr, "Error: out of memory\n");
+    free(image);
+    return NULL;
+  }
+  return image;
 }
 
 /**
@@ -69,72 +67,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-    // Open file for reading
-    FILE *fp = fopen(filename, "rb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s'\n", filename);
-        return NULL;
-    }
+  // Open file for reading
+  FILE *fp = fopen(filename, "rb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s'\n", filename);
+    return NULL;
+  }
 
-    // Read header (magic number, width, and height)
-    char magic[3];
-    uint32_t width;
-    uint32_t height;
-    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-               &height) != 3) {
-        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Make sure the magic number is "P4" (binary PBM format)
-    if (magic[0] != 'P' || magic[1] != '4') {
-        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Allocate memory for buffer
-    size_t buffer_size = (size_t)((width * height + 7) / 8);
-    uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return NULL;
-    }
-
-    // Read pixel data into buffer
-    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Close file
+  // Read header (magic number, width, and height)
+  char magic[3];
+  uint32_t width;
+  uint32_t height;
+  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+             &height) != 3) {
+    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
     fclose(fp);
+    return NULL;
+  }
 
-    // Allocate memory for image data
-    PbmImage *image = AllocatePbm(width, height);
+  // Make sure the magic number is "P4" (binary PBM format)
+  if (magic[0] != 'P' || magic[1] != '4') {
+    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+    fclose(fp);
+    return NULL;
+  }
 
-// Decode the pixel data from the buffer
-    #pragma omp parallel for default(none) shared(image, buffer, width, height)
-    for (size_t i = 0; i < width * height; i += 8) {
-        // Read the next byte from the buffer
-        uint8_t byte = buffer[i / 8];
+  // Allocate memory for buffer
+  size_t buffer_size = (size_t)((width * height + 7) / 8);
+  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return NULL;
+  }
 
-        // Decode the byte into the image data (loop through the 8 bits)
-        for (size_t j = 0; j < 8; j++) {
-            size_t index = i + j;
-            if (index < width * height) {
-                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-            }
-        }
-    }
-
+  // Read pixel data into buffer
+  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+            filename);
     free(buffer);
-    return image;
+    fclose(fp);
+    return NULL;
+  }
+
+  // Close file
+  fclose(fp);
+
+  // Allocate memory for image data
+  PbmImage *image = AllocatePbm(width, height);
+
+  // Decode the pixel data from the buffer
+#pragma omp parallel for default(none) shared(image, buffer, width, height)
+  for (size_t i = 0; i < width * height; i += 8) {
+    // Read the next byte from the buffer
+    uint8_t byte = buffer[i / 8];
+
+    // Decode the byte into the image data (loop through the 8 bits)
+    for (size_t j = 0; j < 8; j++) {
+      size_t index = i + j;
+      if (index < width * height) {
+        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+      }
+    }
+  }
+
+  free(buffer);
+  return image;
 }
 
 /**
@@ -144,12 +142,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-    double *double_data =
-        (double *)malloc(image->width_ * image->height_ * sizeof(double));
-    #pragma omp parallel for default(none) shared(image, double_data)
-    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-        double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
-    return double_data;
+  double *double_data =
+      (double *)malloc(image->width_ * image->height_ * sizeof(double));
+#pragma omp parallel for default(none) shared(image, double_data)
+  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+  return double_data;
 }
 
 /**
@@ -157,9 +155,7 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() {
-    return 128;
-}
+uint8_t MiddleThreshold() { return 128; }
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -167,9 +163,9 @@ uint8_t MiddleThreshold() {
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-    uint8_t random;
-    MyRandom(&random, sizeof(uint8_t));
-    return random;
+  uint8_t random;
+  MyRandom(&random, sizeof(uint8_t));
+  return random;
 }
 
 /**
@@ -181,15 +177,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-// Convert pixel data
-    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-        pbm_image->data_[i] = image->data_[i] < threshold();
+  // Convert pixel data
+#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+    pbm_image->data_[i] = image->data_[i] < threshold();
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -200,55 +196,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Atkinson dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Atkinson dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 1 / 8;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 1 / 8;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
         }
+        double_data[pos + pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -259,23 +255,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-// Convert using Bayer (Ordered) Dithering
-    #pragma omp parallel for default(none)                                         \
+  // Convert using Bayer (Ordered) Dithering
+#pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
-        }
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
     }
+  }
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -286,43 +282,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Floyd-Steinberg dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Floyd-Steinberg dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 16;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 16;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 16;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 16;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -333,61 +329,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Jarvis, Judice, and Ninke dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Jarvis, Judice, and Ninke dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 48;
-            }
-            if (x < pbm_image->width_ - 2) {
-                double_data[pos + 2] += error * 5 / 48;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 48;
+      }
+      if (x < pbm_image->width_ - 2) {
+        double_data[pos + 2] += error * 5 / 48;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -398,47 +394,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-    // Open file for writing
-    FILE *fp = fopen(filename, "wb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-        return false;
-    }
+  // Open file for writing
+  FILE *fp = fopen(filename, "wb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+    return false;
+  }
 
-    // Write header (magic number, width, height)
-    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-        fclose(fp);
-        return false;
-    }
+  // Write header (magic number, width, height)
+  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+    fclose(fp);
+    return false;
+  }
 
-    // Allocate buffer for encoded pixel data
-    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-    uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return false;
-    }
+  // Allocate buffer for encoded pixel data
+  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return false;
+  }
 
-// Encode pixel data
-    #pragma omp parallel for default(none) shared(image, buffer)
-    for (size_t i = 0; i < image->width_ * image->height_; i++) {
-        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-    }
+  // Encode pixel data
+#pragma omp parallel for default(none) shared(image, buffer)
+  for (size_t i = 0; i < image->width_ * image->height_; i++) {
+    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+  }
 
-    // Write encoded pixel data to file
-    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return false;
-    }
-
+  // Write encoded pixel data to file
+  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+            filename);
     free(buffer);
     fclose(fp);
-    return true;
+    return false;
+  }
+
+  free(buffer);
+  fclose(fp);
+  return true;
 }
 
 /**
@@ -447,8 +443,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-    free(image->data_);
-    free(image);
+  free(image->data_);
+  free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -14,8 +14,8 @@
 
 #include <sys/random.h>
 
-ssize_t my_random(void *buf, size_t len) {
-  return getrandom((ssize_t)buf, len, 0);
+ssize_t MyRandom(void *buf, size_t len) {
+  return getrandom(buf, len, 0);
 }
 
 #else /* not linux */
@@ -24,7 +24,7 @@ ssize_t my_random(void *buf, size_t len) {
 #include <stdio.h>
 #include <stdlib.h>
 
-ssize_t my_random(void *buf, size_t len) {
+ssize_t MyRandom(void *buf, size_t len) {
   unsigned char *buffer = (unsigned char *)buf;
   size_t i;
 
@@ -166,7 +166,7 @@ uint8_t MiddleThreshold() { return 128; }
  */
 uint8_t RandomThreshold() {
   uint8_t random;
-  my_random(&random, sizeof(uint8_t));
+  MyRandom(&random, sizeof(uint8_t));
   return random;
 }
 

--- a/pbm.h
+++ b/pbm.h
@@ -14,7 +14,9 @@
 
 #include <sys/random.h>
 
-ssize_t MyRandom(void *buf, size_t len) { return getrandom(buf, len, 0); }
+ssize_t MyRandom(void *buf, size_t len) {
+    return getrandom(buf, len, 0);
+}
 
 #else /* not linux */
 
@@ -23,14 +25,14 @@ ssize_t MyRandom(void *buf, size_t len) { return getrandom(buf, len, 0); }
 #include <stdlib.h>
 
 ssize_t MyRandom(void *buf, size_t len) {
-  unsigned char *buffer = (unsigned char *)buf;
-  size_t i;
+    unsigned char *buffer = (unsigned char *)buf;
+    size_t i;
 
-  for (i = 0; i < len; ++i) {
-    buffer[i] = (unsigned char)rand();
-  }
+    for (i = 0; i < len; ++i) {
+        buffer[i] = (unsigned char)rand();
+    }
 
-  return (ssize_t)len;
+    return (ssize_t)len;
 }
 
 #endif
@@ -43,21 +45,21 @@ ssize_t MyRandom(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-  // Allocate memory for image data
-  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
-  if (!image) {
-    fprintf(stderr, "Error: out of memory\n");
-    return NULL;
-  }
-  image->width_ = width;
-  image->height_ = height;
-  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
-  if (!image->data_) {
-    fprintf(stderr, "Error: out of memory\n");
-    free(image);
-    return NULL;
-  }
-  return image;
+    // Allocate memory for image data
+    PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+    if (!image) {
+        fprintf(stderr, "Error: out of memory\n");
+        return NULL;
+    }
+    image->width_ = width;
+    image->height_ = height;
+    image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+    if (!image->data_) {
+        fprintf(stderr, "Error: out of memory\n");
+        free(image);
+        return NULL;
+    }
+    return image;
 }
 
 /**
@@ -67,72 +69,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-  // Open file for reading
-  FILE *fp = fopen(filename, "rb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s'\n", filename);
-    return NULL;
-  }
-
-  // Read header (magic number, width, and height)
-  char magic[3];
-  uint32_t width;
-  uint32_t height;
-  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-             &height) != 3) {
-    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Make sure the magic number is "P4" (binary PBM format)
-  if (magic[0] != 'P' || magic[1] != '4') {
-    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Allocate memory for buffer
-  size_t buffer_size = (size_t)((width * height + 7) / 8);
-  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return NULL;
-  }
-
-  // Read pixel data into buffer
-  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-            filename);
-    free(buffer);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Close file
-  fclose(fp);
-
-  // Allocate memory for image data
-  PbmImage *image = AllocatePbm(width, height);
-
-  // Decode the pixel data from the buffer
-#pragma omp parallel for default(none) shared(image, buffer, width, height)
-  for (size_t i = 0; i < width * height; i += 8) {
-    // Read the next byte from the buffer
-    uint8_t byte = buffer[i / 8];
-
-    // Decode the byte into the image data (loop through the 8 bits)
-    for (size_t j = 0; j < 8; j++) {
-      size_t index = i + j;
-      if (index < width * height) {
-        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-      }
+    // Open file for reading
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s'\n", filename);
+        return NULL;
     }
-  }
 
-  free(buffer);
-  return image;
+    // Read header (magic number, width, and height)
+    char magic[3];
+    uint32_t width;
+    uint32_t height;
+    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+               &height) != 3) {
+        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Make sure the magic number is "P4" (binary PBM format)
+    if (magic[0] != 'P' || magic[1] != '4') {
+        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Allocate memory for buffer
+    size_t buffer_size = (size_t)((width * height + 7) / 8);
+    uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    // Read pixel data into buffer
+    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Close file
+    fclose(fp);
+
+    // Allocate memory for image data
+    PbmImage *image = AllocatePbm(width, height);
+
+    // Decode the pixel data from the buffer
+    #pragma omp parallel for default(none) shared(image, buffer, width, height)
+    for (size_t i = 0; i < width * height; i += 8) {
+        // Read the next byte from the buffer
+        uint8_t byte = buffer[i / 8];
+
+        // Decode the byte into the image data (loop through the 8 bits)
+        for (size_t j = 0; j < 8; j++) {
+            size_t index = i + j;
+            if (index < width * height) {
+                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+            }
+        }
+    }
+
+    free(buffer);
+    return image;
 }
 
 /**
@@ -142,12 +144,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-  double *double_data =
-      (double *)malloc(image->width_ * image->height_ * sizeof(double));
-#pragma omp parallel for default(none) shared(image, double_data)
-  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
-  return double_data;
+    double *double_data =
+        (double *)malloc(image->width_ * image->height_ * sizeof(double));
+    #pragma omp parallel for default(none) shared(image, double_data)
+    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+        double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+    return double_data;
 }
 
 /**
@@ -155,7 +157,9 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() { return 128; }
+uint8_t MiddleThreshold() {
+    return 128;
+}
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -163,9 +167,9 @@ uint8_t MiddleThreshold() { return 128; }
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-  uint8_t random;
-  MyRandom(&random, sizeof(uint8_t));
-  return random;
+    uint8_t random;
+    MyRandom(&random, sizeof(uint8_t));
+    return random;
 }
 
 /**
@@ -177,15 +181,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Convert pixel data
-#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-    pbm_image->data_[i] = image->data_[i] < threshold();
+    // Convert pixel data
+    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+        pbm_image->data_[i] = image->data_[i] < threshold();
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -196,55 +200,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Atkinson dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Atkinson dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 1 / 8;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 1 / 8;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -255,23 +259,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert using Bayer (Ordered) Dithering
-#pragma omp parallel for default(none)                                         \
+    // Convert using Bayer (Ordered) Dithering
+    #pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+        }
     }
-  }
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -282,43 +286,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Floyd-Steinberg dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Floyd-Steinberg dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 16;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 16;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 16;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 16;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -329,61 +333,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Jarvis, Judice, and Ninke dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Jarvis, Judice, and Ninke dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 48;
-      }
-      if (x < pbm_image->width_ - 2) {
-        double_data[pos + 2] += error * 5 / 48;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 48;
+            }
+            if (x < pbm_image->width_ - 2) {
+                double_data[pos + 2] += error * 5 / 48;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -394,47 +398,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-  // Open file for writing
-  FILE *fp = fopen(filename, "wb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-    return false;
-  }
+    // Open file for writing
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+        return false;
+    }
 
-  // Write header (magic number, width, height)
-  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-    fclose(fp);
-    return false;
-  }
+    // Write header (magic number, width, height)
+    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+        fclose(fp);
+        return false;
+    }
 
-  // Allocate buffer for encoded pixel data
-  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return false;
-  }
+    // Allocate buffer for encoded pixel data
+    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+    uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return false;
+    }
 
-  // Encode pixel data
-#pragma omp parallel for default(none) shared(image, buffer)
-  for (size_t i = 0; i < image->width_ * image->height_; i++) {
-    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-  }
+    // Encode pixel data
+    #pragma omp parallel for default(none) shared(image, buffer)
+    for (size_t i = 0; i < image->width_ * image->height_; i++) {
+        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+    }
 
-  // Write encoded pixel data to file
-  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-            filename);
+    // Write encoded pixel data to file
+    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return false;
+    }
+
     free(buffer);
     fclose(fp);
-    return false;
-  }
-
-  free(buffer);
-  fclose(fp);
-  return true;
+    return true;
 }
 
 /**
@@ -443,8 +447,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-  free(image->data_);
-  free(image);
+    free(image->data_);
+    free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -15,7 +15,7 @@
 #include <sys/random.h>
 
 ssize_t my_random(void *buf, size_t len) {
-    return getrandom((ssize_t)buf, len, 0);
+  return getrandom((ssize_t)buf, len, 0);
 }
 
 #else /* not linux */
@@ -25,14 +25,14 @@ ssize_t my_random(void *buf, size_t len) {
 #include <stdlib.h>
 
 ssize_t my_random(void *buf, size_t len) {
-    unsigned char *buffer = (unsigned char *)buf;
-    size_t i;
+  unsigned char *buffer = (unsigned char *)buf;
+  size_t i;
 
-    for (i = 0; i < len; ++i) {
-        buffer[i] = (unsigned char)rand();
-    }
+  for (i = 0; i < len; ++i) {
+    buffer[i] = (unsigned char)rand();
+  }
 
-    return (ssize_t)len;
+  return (ssize_t)len;
 }
 
 #endif
@@ -45,21 +45,21 @@ ssize_t my_random(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-    // Allocate memory for image data
-    PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
-    if (!image) {
-        fprintf(stderr, "Error: out of memory\n");
-        return NULL;
-    }
-    image->width_ = width;
-    image->height_ = height;
-    image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
-    if (!image->data_) {
-        fprintf(stderr, "Error: out of memory\n");
-        free(image);
-        return NULL;
-    }
-    return image;
+  // Allocate memory for image data
+  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+  if (!image) {
+    fprintf(stderr, "Error: out of memory\n");
+    return NULL;
+  }
+  image->width_ = width;
+  image->height_ = height;
+  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+  if (!image->data_) {
+    fprintf(stderr, "Error: out of memory\n");
+    free(image);
+    return NULL;
+  }
+  return image;
 }
 
 /**
@@ -69,72 +69,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-    // Open file for reading
-    FILE *fp = fopen(filename, "rb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s'\n", filename);
-        return NULL;
-    }
+  // Open file for reading
+  FILE *fp = fopen(filename, "rb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s'\n", filename);
+    return NULL;
+  }
 
-    // Read header (magic number, width, and height)
-    char magic[3];
-    uint32_t width;
-    uint32_t height;
-    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-               &height) != 3) {
-        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Make sure the magic number is "P4" (binary PBM format)
-    if (magic[0] != 'P' || magic[1] != '4') {
-        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Allocate memory for buffer
-    size_t buffer_size = (size_t)((width * height + 7) / 8);
-    uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return NULL;
-    }
-
-    // Read pixel data into buffer
-    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Close file
+  // Read header (magic number, width, and height)
+  char magic[3];
+  uint32_t width;
+  uint32_t height;
+  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+             &height) != 3) {
+    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
     fclose(fp);
+    return NULL;
+  }
 
-    // Allocate memory for image data
-    PbmImage *image = AllocatePbm(width, height);
+  // Make sure the magic number is "P4" (binary PBM format)
+  if (magic[0] != 'P' || magic[1] != '4') {
+    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+    fclose(fp);
+    return NULL;
+  }
 
-    // Decode the pixel data from the buffer
-    #pragma omp parallel for default(none) shared(image, buffer, width, height)
-    for (size_t i = 0; i < width * height; i += 8) {
-        // Read the next byte from the buffer
-        uint8_t byte = buffer[i / 8];
+  // Allocate memory for buffer
+  size_t buffer_size = (size_t)((width * height + 7) / 8);
+  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return NULL;
+  }
 
-        // Decode the byte into the image data (loop through the 8 bits)
-        for (size_t j = 0; j < 8; j++) {
-            size_t index = i + j;
-            if (index < width * height) {
-                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-            }
-        }
-    }
-
+  // Read pixel data into buffer
+  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+            filename);
     free(buffer);
-    return image;
+    fclose(fp);
+    return NULL;
+  }
+
+  // Close file
+  fclose(fp);
+
+  // Allocate memory for image data
+  PbmImage *image = AllocatePbm(width, height);
+
+// Decode the pixel data from the buffer
+#pragma omp parallel for default(none) shared(image, buffer, width, height)
+  for (size_t i = 0; i < width * height; i += 8) {
+    // Read the next byte from the buffer
+    uint8_t byte = buffer[i / 8];
+
+    // Decode the byte into the image data (loop through the 8 bits)
+    for (size_t j = 0; j < 8; j++) {
+      size_t index = i + j;
+      if (index < width * height) {
+        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+      }
+    }
+  }
+
+  free(buffer);
+  return image;
 }
 
 /**
@@ -144,12 +144,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-    double *double_data =
-        (double *)malloc(image->width_ * image->height_ * sizeof(double));
-    #pragma omp parallel for default(none) shared(image, double_data)
-    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-        double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
-    return double_data;
+  double *double_data =
+      (double *)malloc(image->width_ * image->height_ * sizeof(double));
+#pragma omp parallel for default(none) shared(image, double_data)
+  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+  return double_data;
 }
 
 /**
@@ -157,9 +157,7 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() {
-    return 128;
-}
+uint8_t MiddleThreshold() { return 128; }
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -167,9 +165,9 @@ uint8_t MiddleThreshold() {
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-    uint8_t random;
-    my_random(&random, sizeof(uint8_t));
-    return random;
+  uint8_t random;
+  my_random(&random, sizeof(uint8_t));
+  return random;
 }
 
 /**
@@ -181,15 +179,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Convert pixel data
-    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-        pbm_image->data_[i] = image->data_[i] < threshold();
+// Convert pixel data
+#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+    pbm_image->data_[i] = image->data_[i] < threshold();
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -200,55 +198,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Atkinson dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Atkinson dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 1 / 8;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 1 / 8;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
         }
+        double_data[pos + pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -259,23 +257,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert using Bayer (Ordered) Dithering
-    #pragma omp parallel for default(none)                                         \
+// Convert using Bayer (Ordered) Dithering
+#pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
-        }
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
     }
+  }
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -286,43 +284,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Floyd-Steinberg dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Floyd-Steinberg dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 16;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 16;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 16;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 16;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -333,61 +331,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Jarvis, Judice, and Ninke dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Jarvis, Judice, and Ninke dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 48;
-            }
-            if (x < pbm_image->width_ - 2) {
-                double_data[pos + 2] += error * 5 / 48;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 48;
+      }
+      if (x < pbm_image->width_ - 2) {
+        double_data[pos + 2] += error * 5 / 48;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -398,47 +396,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-    // Open file for writing
-    FILE *fp = fopen(filename, "wb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-        return false;
-    }
+  // Open file for writing
+  FILE *fp = fopen(filename, "wb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+    return false;
+  }
 
-    // Write header (magic number, width, height)
-    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-        fclose(fp);
-        return false;
-    }
+  // Write header (magic number, width, height)
+  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+    fclose(fp);
+    return false;
+  }
 
-    // Allocate buffer for encoded pixel data
-    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-    uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return false;
-    }
+  // Allocate buffer for encoded pixel data
+  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return false;
+  }
 
-    // Encode pixel data
-    #pragma omp parallel for default(none) shared(image, buffer)
-    for (size_t i = 0; i < image->width_ * image->height_; i++) {
-        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-    }
+// Encode pixel data
+#pragma omp parallel for default(none) shared(image, buffer)
+  for (size_t i = 0; i < image->width_ * image->height_; i++) {
+    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+  }
 
-    // Write encoded pixel data to file
-    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return false;
-    }
-
+  // Write encoded pixel data to file
+  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+            filename);
     free(buffer);
     fclose(fp);
-    return true;
+    return false;
+  }
+
+  free(buffer);
+  fclose(fp);
+  return true;
 }
 
 /**
@@ -447,8 +445,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-    free(image->data_);
-    free(image);
+  free(image->data_);
+  free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -15,7 +15,7 @@
 #include <sys/random.h>
 
 ssize_t my_random(void *buf, size_t len) {
-  return getrandom((ssize_t)buf, len, 0);
+    return getrandom((ssize_t)buf, len, 0);
 }
 
 #else /* not linux */
@@ -25,14 +25,14 @@ ssize_t my_random(void *buf, size_t len) {
 #include <stdlib.h>
 
 ssize_t my_random(void *buf, size_t len) {
-  unsigned char *buffer = (unsigned char *)buf;
-  size_t i;
+    unsigned char *buffer = (unsigned char *)buf;
+    size_t i;
 
-  for (i = 0; i < len; ++i) {
-    buffer[i] = (unsigned char)rand();
-  }
+    for (i = 0; i < len; ++i) {
+        buffer[i] = (unsigned char)rand();
+    }
 
-  return (ssize_t)len;
+    return (ssize_t)len;
 }
 
 #endif
@@ -45,21 +45,21 @@ ssize_t my_random(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-  // Allocate memory for image data
-  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
-  if (!image) {
-    fprintf(stderr, "Error: out of memory\n");
-    return NULL;
-  }
-  image->width_ = width;
-  image->height_ = height;
-  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
-  if (!image->data_) {
-    fprintf(stderr, "Error: out of memory\n");
-    free(image);
-    return NULL;
-  }
-  return image;
+    // Allocate memory for image data
+    PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+    if (!image) {
+        fprintf(stderr, "Error: out of memory\n");
+        return NULL;
+    }
+    image->width_ = width;
+    image->height_ = height;
+    image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+    if (!image->data_) {
+        fprintf(stderr, "Error: out of memory\n");
+        free(image);
+        return NULL;
+    }
+    return image;
 }
 
 /**
@@ -69,72 +69,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-  // Open file for reading
-  FILE *fp = fopen(filename, "rb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s'\n", filename);
-    return NULL;
-  }
-
-  // Read header (magic number, width, and height)
-  char magic[3];
-  uint32_t width;
-  uint32_t height;
-  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-             &height) != 3) {
-    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Make sure the magic number is "P4" (binary PBM format)
-  if (magic[0] != 'P' || magic[1] != '4') {
-    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Allocate memory for buffer
-  size_t buffer_size = (size_t)((width * height + 7) / 8);
-  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return NULL;
-  }
-
-  // Read pixel data into buffer
-  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-            filename);
-    free(buffer);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Close file
-  fclose(fp);
-
-  // Allocate memory for image data
-  PbmImage *image = AllocatePbm(width, height);
-
-  // Decode the pixel data from the buffer
-#pragma omp parallel for default(none) shared(image, buffer, width, height)
-  for (size_t i = 0; i < width * height; i += 8) {
-    // Read the next byte from the buffer
-    uint8_t byte = buffer[i / 8];
-
-    // Decode the byte into the image data (loop through the 8 bits)
-    for (size_t j = 0; j < 8; j++) {
-      size_t index = i + j;
-      if (index < width * height) {
-        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-      }
+    // Open file for reading
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s'\n", filename);
+        return NULL;
     }
-  }
 
-  free(buffer);
-  return image;
+    // Read header (magic number, width, and height)
+    char magic[3];
+    uint32_t width;
+    uint32_t height;
+    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+               &height) != 3) {
+        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Make sure the magic number is "P4" (binary PBM format)
+    if (magic[0] != 'P' || magic[1] != '4') {
+        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Allocate memory for buffer
+    size_t buffer_size = (size_t)((width * height + 7) / 8);
+    uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    // Read pixel data into buffer
+    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Close file
+    fclose(fp);
+
+    // Allocate memory for image data
+    PbmImage *image = AllocatePbm(width, height);
+
+    // Decode the pixel data from the buffer
+    #pragma omp parallel for default(none) shared(image, buffer, width, height)
+    for (size_t i = 0; i < width * height; i += 8) {
+        // Read the next byte from the buffer
+        uint8_t byte = buffer[i / 8];
+
+        // Decode the byte into the image data (loop through the 8 bits)
+        for (size_t j = 0; j < 8; j++) {
+            size_t index = i + j;
+            if (index < width * height) {
+                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+            }
+        }
+    }
+
+    free(buffer);
+    return image;
 }
 
 /**
@@ -144,12 +144,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-  double *double_data =
-      (double *)malloc(image->width_ * image->height_ * sizeof(double));
-#pragma omp parallel for default(none) shared(image, double_data)
-  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
-  return double_data;
+    double *double_data =
+        (double *)malloc(image->width_ * image->height_ * sizeof(double));
+    #pragma omp parallel for default(none) shared(image, double_data)
+    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+        double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+    return double_data;
 }
 
 /**
@@ -157,7 +157,9 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() { return 128; }
+uint8_t MiddleThreshold() {
+    return 128;
+}
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -165,9 +167,9 @@ uint8_t MiddleThreshold() { return 128; }
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-  uint8_t random;
-  my_random(&random, sizeof(uint8_t));
-  return random;
+    uint8_t random;
+    my_random(&random, sizeof(uint8_t));
+    return random;
 }
 
 /**
@@ -179,15 +181,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Convert pixel data
-#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-    pbm_image->data_[i] = image->data_[i] < threshold();
+    // Convert pixel data
+    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+        pbm_image->data_[i] = image->data_[i] < threshold();
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -198,55 +200,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Atkinson dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Atkinson dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 1 / 8;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 1 / 8;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -257,23 +259,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert using Bayer (Ordered) Dithering
-#pragma omp parallel for default(none)                                         \
+    // Convert using Bayer (Ordered) Dithering
+    #pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+        }
     }
-  }
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -284,43 +286,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Floyd-Steinberg dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Floyd-Steinberg dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 16;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 16;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 16;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 16;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -331,61 +333,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Jarvis, Judice, and Ninke dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Jarvis, Judice, and Ninke dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 48;
-      }
-      if (x < pbm_image->width_ - 2) {
-        double_data[pos + 2] += error * 5 / 48;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 48;
+            }
+            if (x < pbm_image->width_ - 2) {
+                double_data[pos + 2] += error * 5 / 48;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -396,47 +398,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-  // Open file for writing
-  FILE *fp = fopen(filename, "wb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-    return false;
-  }
+    // Open file for writing
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+        return false;
+    }
 
-  // Write header (magic number, width, height)
-  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-    fclose(fp);
-    return false;
-  }
+    // Write header (magic number, width, height)
+    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+        fclose(fp);
+        return false;
+    }
 
-  // Allocate buffer for encoded pixel data
-  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return false;
-  }
+    // Allocate buffer for encoded pixel data
+    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+    uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return false;
+    }
 
-  // Encode pixel data
-#pragma omp parallel for default(none) shared(image, buffer)
-  for (size_t i = 0; i < image->width_ * image->height_; i++) {
-    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-  }
+    // Encode pixel data
+    #pragma omp parallel for default(none) shared(image, buffer)
+    for (size_t i = 0; i < image->width_ * image->height_; i++) {
+        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+    }
 
-  // Write encoded pixel data to file
-  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-            filename);
+    // Write encoded pixel data to file
+    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return false;
+    }
+
     free(buffer);
     fclose(fp);
-    return false;
-  }
-
-  free(buffer);
-  fclose(fp);
-  return true;
+    return true;
 }
 
 /**
@@ -445,8 +447,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-  free(image->data_);
-  free(image);
+    free(image->data_);
+    free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -12,32 +12,30 @@
 
 #if defined __GLIBC__ && defined __linux__
 
-#  include <sys/random.h>
+#include <sys/random.h>
 
-ssize_t my_random(void *buf, size_t len)
-{
-    return getrandom((ssize_t) buf, len, 0);
+ssize_t my_random(void *buf, size_t len) {
+  return getrandom((ssize_t)buf, len, 0);
 }
 
 #else /* not linux */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 
 ssize_t my_random(void *buf, size_t len) {
-    unsigned char *buffer = (unsigned char*)buf;
-    size_t i;
+  unsigned char *buffer = (unsigned char *)buf;
+  size_t i;
 
-    for (i = 0; i < len; ++i) {
-        buffer[i] = (unsigned char) rand();
-    }
+  for (i = 0; i < len; ++i) {
+    buffer[i] = (unsigned char)rand();
+  }
 
-    return (ssize_t) len;
+  return (ssize_t)len;
 }
 
 #endif
-
 
 /**
  * Allocate memory for a PBM image.
@@ -47,21 +45,21 @@ ssize_t my_random(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-    // Allocate memory for image data
-    PbmImage *image = (PbmImage *) malloc(sizeof(PbmImage));
-    if (!image) {
-        fprintf(stderr, "Error: out of memory\n");
-        return NULL;
-    }
-    image->width_ = width;
-    image->height_ = height;
-    image->data_ = (uint8_t *) malloc(width * height * sizeof(uint8_t));
-    if (!image->data_) {
-        fprintf(stderr, "Error: out of memory\n");
-        free(image);
-        return NULL;
-    }
-    return image;
+  // Allocate memory for image data
+  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+  if (!image) {
+    fprintf(stderr, "Error: out of memory\n");
+    return NULL;
+  }
+  image->width_ = width;
+  image->height_ = height;
+  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+  if (!image->data_) {
+    fprintf(stderr, "Error: out of memory\n");
+    free(image);
+    return NULL;
+  }
+  return image;
 }
 
 /**
@@ -71,72 +69,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-    // Open file for reading
-    FILE *fp = fopen(filename, "rb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s'\n", filename);
-        return NULL;
-    }
+  // Open file for reading
+  FILE *fp = fopen(filename, "rb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s'\n", filename);
+    return NULL;
+  }
 
-    // Read header (magic number, width, and height)
-    char magic[3];
-    uint32_t width;
-    uint32_t height;
-    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-               &height) != 3) {
-        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Make sure the magic number is "P4" (binary PBM format)
-    if (magic[0] != 'P' || magic[1] != '4') {
-        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Allocate memory for buffer
-    size_t buffer_size = (size_t) ((width * height + 7) / 8);
-    uint8_t *buffer = (uint8_t *) malloc(buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return NULL;
-    }
-
-    // Read pixel data into buffer
-    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Close file
+  // Read header (magic number, width, and height)
+  char magic[3];
+  uint32_t width;
+  uint32_t height;
+  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+             &height) != 3) {
+    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
     fclose(fp);
+    return NULL;
+  }
 
-    // Allocate memory for image data
-    PbmImage *image = AllocatePbm(width, height);
+  // Make sure the magic number is "P4" (binary PBM format)
+  if (magic[0] != 'P' || magic[1] != '4') {
+    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+    fclose(fp);
+    return NULL;
+  }
 
-// Decode the pixel data from the buffer
-    #pragma omp parallel for default(none) shared(image, buffer, width, height)
-    for (size_t i = 0; i < width * height; i += 8) {
-        // Read the next byte from the buffer
-        uint8_t byte = buffer[i / 8];
+  // Allocate memory for buffer
+  size_t buffer_size = (size_t)((width * height + 7) / 8);
+  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return NULL;
+  }
 
-        // Decode the byte into the image data (loop through the 8 bits)
-        for (size_t j = 0; j < 8; j++) {
-            size_t index = i + j;
-            if (index < width * height) {
-                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-            }
-        }
-    }
-
+  // Read pixel data into buffer
+  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+            filename);
     free(buffer);
-    return image;
+    fclose(fp);
+    return NULL;
+  }
+
+  // Close file
+  fclose(fp);
+
+  // Allocate memory for image data
+  PbmImage *image = AllocatePbm(width, height);
+
+  // Decode the pixel data from the buffer
+#pragma omp parallel for default(none) shared(image, buffer, width, height)
+  for (size_t i = 0; i < width * height; i += 8) {
+    // Read the next byte from the buffer
+    uint8_t byte = buffer[i / 8];
+
+    // Decode the byte into the image data (loop through the 8 bits)
+    for (size_t j = 0; j < 8; j++) {
+      size_t index = i + j;
+      if (index < width * height) {
+        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+      }
+    }
+  }
+
+  free(buffer);
+  return image;
 }
 
 /**
@@ -146,12 +144,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-    double *double_data =
-        (double *) malloc(image->width_ * image->height_ * sizeof(double));
-    #pragma omp parallel for default(none) shared(image, double_data)
-    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-        double_data[i] = (double) image->data_[i] / PGM_MAX_GRAY_F;
-    return double_data;
+  double *double_data =
+      (double *)malloc(image->width_ * image->height_ * sizeof(double));
+#pragma omp parallel for default(none) shared(image, double_data)
+  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+  return double_data;
 }
 
 /**
@@ -159,9 +157,7 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() {
-    return 128;
-}
+uint8_t MiddleThreshold() { return 128; }
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -169,9 +165,9 @@ uint8_t MiddleThreshold() {
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-    uint8_t random;
-    my_random(&random, sizeof(uint8_t));
-    return random;
+  uint8_t random;
+  my_random(&random, sizeof(uint8_t));
+  return random;
 }
 
 /**
@@ -183,15 +179,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-// Convert pixel data
-    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-        pbm_image->data_[i] = image->data_[i] < threshold();
+  // Convert pixel data
+#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+    pbm_image->data_[i] = image->data_[i] < threshold();
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -202,55 +198,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Atkinson dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Atkinson dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 1 / 8;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 1 / 8;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
         }
+        double_data[pos + pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -261,23 +257,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-// Convert using Bayer (Ordered) Dithering
-    #pragma omp parallel for default(none)                                         \
+  // Convert using Bayer (Ordered) Dithering
+#pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
-        }
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
     }
+  }
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -288,43 +284,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Floyd-Steinberg dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Floyd-Steinberg dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 16;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 16;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 16;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 16;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -335,61 +331,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Jarvis, Judice, and Ninke dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Jarvis, Judice, and Ninke dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 48;
-            }
-            if (x < pbm_image->width_ - 2) {
-                double_data[pos + 2] += error * 5 / 48;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 48;
+      }
+      if (x < pbm_image->width_ - 2) {
+        double_data[pos + 2] += error * 5 / 48;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -400,47 +396,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-    // Open file for writing
-    FILE *fp = fopen(filename, "wb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-        return false;
-    }
+  // Open file for writing
+  FILE *fp = fopen(filename, "wb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+    return false;
+  }
 
-    // Write header (magic number, width, height)
-    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-        fclose(fp);
-        return false;
-    }
+  // Write header (magic number, width, height)
+  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+    fclose(fp);
+    return false;
+  }
 
-    // Allocate buffer for encoded pixel data
-    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-    uint8_t *buffer = (uint8_t *) calloc(1, buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return false;
-    }
+  // Allocate buffer for encoded pixel data
+  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return false;
+  }
 
-// Encode pixel data
-    #pragma omp parallel for default(none) shared(image, buffer)
-    for (size_t i = 0; i < image->width_ * image->height_; i++) {
-        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-    }
+  // Encode pixel data
+#pragma omp parallel for default(none) shared(image, buffer)
+  for (size_t i = 0; i < image->width_ * image->height_; i++) {
+    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+  }
 
-    // Write encoded pixel data to file
-    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return false;
-    }
-
+  // Write encoded pixel data to file
+  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+            filename);
     free(buffer);
     fclose(fp);
-    return true;
+    return false;
+  }
+
+  free(buffer);
+  fclose(fp);
+  return true;
 }
 
 /**
@@ -449,8 +445,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-    free(image->data_);
-    free(image);
+  free(image->data_);
+  free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -9,7 +9,35 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/random.h>
+
+#if defined __GLIBC__ && defined __linux__
+
+#  include <sys/random.h>
+
+ssize_t my_random(void *buf, size_t len)
+{
+    return getrandom((ssize_t) buf, len, 0);
+}
+
+#else /* not linux */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+ssize_t my_random(void *buf, size_t len) {
+    unsigned char *buffer = (unsigned char*)buf;
+    size_t i;
+
+    for (i = 0; i < len; ++i) {
+        buffer[i] = (unsigned char) rand();
+    }
+
+    return (ssize_t) len;
+}
+
+#endif
+
 
 /**
  * Allocate memory for a PBM image.
@@ -140,7 +168,7 @@ uint8_t MiddleThreshold() { return 128; }
  */
 uint8_t RandomThreshold() {
   uint8_t random;
-  getrandom(&random, sizeof(uint8_t), 0);
+    my_random(&random, sizeof(uint8_t));
   return random;
 }
 

--- a/pbm.h
+++ b/pbm.h
@@ -15,7 +15,7 @@
 #include <sys/random.h>
 
 ssize_t MyRandom(void *buf, size_t len) {
-  return getrandom(buf, len, 0);
+    return getrandom(buf, len, 0);
 }
 
 #else /* not linux */
@@ -25,14 +25,14 @@ ssize_t MyRandom(void *buf, size_t len) {
 #include <stdlib.h>
 
 ssize_t MyRandom(void *buf, size_t len) {
-  unsigned char *buffer = (unsigned char *)buf;
-  size_t i;
+    unsigned char *buffer = (unsigned char *)buf;
+    size_t i;
 
-  for (i = 0; i < len; ++i) {
-    buffer[i] = (unsigned char)rand();
-  }
+    for (i = 0; i < len; ++i) {
+        buffer[i] = (unsigned char)rand();
+    }
 
-  return (ssize_t)len;
+    return (ssize_t)len;
 }
 
 #endif
@@ -45,21 +45,21 @@ ssize_t MyRandom(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-  // Allocate memory for image data
-  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
-  if (!image) {
-    fprintf(stderr, "Error: out of memory\n");
-    return NULL;
-  }
-  image->width_ = width;
-  image->height_ = height;
-  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
-  if (!image->data_) {
-    fprintf(stderr, "Error: out of memory\n");
-    free(image);
-    return NULL;
-  }
-  return image;
+    // Allocate memory for image data
+    PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+    if (!image) {
+        fprintf(stderr, "Error: out of memory\n");
+        return NULL;
+    }
+    image->width_ = width;
+    image->height_ = height;
+    image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+    if (!image->data_) {
+        fprintf(stderr, "Error: out of memory\n");
+        free(image);
+        return NULL;
+    }
+    return image;
 }
 
 /**
@@ -69,72 +69,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-  // Open file for reading
-  FILE *fp = fopen(filename, "rb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s'\n", filename);
-    return NULL;
-  }
+    // Open file for reading
+    FILE *fp = fopen(filename, "rb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s'\n", filename);
+        return NULL;
+    }
 
-  // Read header (magic number, width, and height)
-  char magic[3];
-  uint32_t width;
-  uint32_t height;
-  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-             &height) != 3) {
-    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
+    // Read header (magic number, width, and height)
+    char magic[3];
+    uint32_t width;
+    uint32_t height;
+    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+               &height) != 3) {
+        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Make sure the magic number is "P4" (binary PBM format)
+    if (magic[0] != 'P' || magic[1] != '4') {
+        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Allocate memory for buffer
+    size_t buffer_size = (size_t)((width * height + 7) / 8);
+    uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return NULL;
+    }
+
+    // Read pixel data into buffer
+    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return NULL;
+    }
+
+    // Close file
     fclose(fp);
-    return NULL;
-  }
 
-  // Make sure the magic number is "P4" (binary PBM format)
-  if (magic[0] != 'P' || magic[1] != '4') {
-    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Allocate memory for buffer
-  size_t buffer_size = (size_t)((width * height + 7) / 8);
-  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return NULL;
-  }
-
-  // Read pixel data into buffer
-  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-            filename);
-    free(buffer);
-    fclose(fp);
-    return NULL;
-  }
-
-  // Close file
-  fclose(fp);
-
-  // Allocate memory for image data
-  PbmImage *image = AllocatePbm(width, height);
+    // Allocate memory for image data
+    PbmImage *image = AllocatePbm(width, height);
 
 // Decode the pixel data from the buffer
-#pragma omp parallel for default(none) shared(image, buffer, width, height)
-  for (size_t i = 0; i < width * height; i += 8) {
-    // Read the next byte from the buffer
-    uint8_t byte = buffer[i / 8];
+    #pragma omp parallel for default(none) shared(image, buffer, width, height)
+    for (size_t i = 0; i < width * height; i += 8) {
+        // Read the next byte from the buffer
+        uint8_t byte = buffer[i / 8];
 
-    // Decode the byte into the image data (loop through the 8 bits)
-    for (size_t j = 0; j < 8; j++) {
-      size_t index = i + j;
-      if (index < width * height) {
-        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-      }
+        // Decode the byte into the image data (loop through the 8 bits)
+        for (size_t j = 0; j < 8; j++) {
+            size_t index = i + j;
+            if (index < width * height) {
+                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+            }
+        }
     }
-  }
 
-  free(buffer);
-  return image;
+    free(buffer);
+    return image;
 }
 
 /**
@@ -144,12 +144,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-  double *double_data =
-      (double *)malloc(image->width_ * image->height_ * sizeof(double));
-#pragma omp parallel for default(none) shared(image, double_data)
-  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
-  return double_data;
+    double *double_data =
+        (double *)malloc(image->width_ * image->height_ * sizeof(double));
+    #pragma omp parallel for default(none) shared(image, double_data)
+    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+        double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+    return double_data;
 }
 
 /**
@@ -157,7 +157,9 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() { return 128; }
+uint8_t MiddleThreshold() {
+    return 128;
+}
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -165,9 +167,9 @@ uint8_t MiddleThreshold() { return 128; }
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-  uint8_t random;
-  MyRandom(&random, sizeof(uint8_t));
-  return random;
+    uint8_t random;
+    MyRandom(&random, sizeof(uint8_t));
+    return random;
 }
 
 /**
@@ -179,15 +181,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
 // Convert pixel data
-#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-    pbm_image->data_[i] = image->data_[i] < threshold();
+    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+        pbm_image->data_[i] = image->data_[i] < threshold();
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -198,55 +200,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Atkinson dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Atkinson dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 1 / 8;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 1 / 8;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -257,23 +259,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
 // Convert using Bayer (Ordered) Dithering
-#pragma omp parallel for default(none)                                         \
+    #pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
+        }
     }
-  }
 
-  return pbm_image;
+    return pbm_image;
 }
 
 /**
@@ -284,43 +286,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Floyd-Steinberg dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Floyd-Steinberg dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 16;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 16;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 16;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 16;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -331,61 +333,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-  // Allocate memory for new image data
-  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+    // Allocate memory for new image data
+    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-  // Normalize pixel data to [0, 1] double values
-  double *double_data = NormalizePgm(image);
+    // Normalize pixel data to [0, 1] double values
+    double *double_data = NormalizePgm(image);
 
-  // Convert pixel data using Jarvis, Judice, and Ninke dithering
-  for (uint32_t y = 0; y < pbm_image->height_; y++) {
-    for (uint32_t x = 0; x < pbm_image->width_; x++) {
-      uint32_t pos = y * pbm_image->width_ + x;
-      double old_pixel = double_data[pos];
-      double new_pixel = round(old_pixel);
+    // Convert pixel data using Jarvis, Judice, and Ninke dithering
+    for (uint32_t y = 0; y < pbm_image->height_; y++) {
+        for (uint32_t x = 0; x < pbm_image->width_; x++) {
+            uint32_t pos = y * pbm_image->width_ + x;
+            double old_pixel = double_data[pos];
+            double new_pixel = round(old_pixel);
 
-      // Invert pixel value (PBM is white 0 and black 1)
-      pbm_image->data_[pos] = new_pixel == 0;
+            // Invert pixel value (PBM is white 0 and black 1)
+            pbm_image->data_[pos] = new_pixel == 0;
 
-      // Calculate error
-      double error = old_pixel - new_pixel;
+            // Calculate error
+            double error = old_pixel - new_pixel;
 
-      // Propagate error
-      if (x < pbm_image->width_ - 1) {
-        double_data[pos + 1] += error * 7 / 48;
-      }
-      if (x < pbm_image->width_ - 2) {
-        double_data[pos + 2] += error * 5 / 48;
-      }
-      if (y < pbm_image->height_ - 1) {
-        if (x > 0) {
-          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+            // Propagate error
+            if (x < pbm_image->width_ - 1) {
+                double_data[pos + 1] += error * 7 / 48;
+            }
+            if (x < pbm_image->width_ - 2) {
+                double_data[pos + 2] += error * 5 / 48;
+            }
+            if (y < pbm_image->height_ - 1) {
+                if (x > 0) {
+                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
+                }
+                double_data[pos + pbm_image->width_] += error * 5 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+                }
+            }
+            if (y < pbm_image->height_ - 2) {
+                if (x > 0) {
+                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+                }
+                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+                if (x < pbm_image->width_ - 1) {
+                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+                }
+                if (x < pbm_image->width_ - 2) {
+                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+                }
+            }
         }
-        double_data[pos + pbm_image->width_] += error * 5 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-        }
-      }
-      if (y < pbm_image->height_ - 2) {
-        if (x > 0) {
-          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-        }
-        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-        if (x < pbm_image->width_ - 1) {
-          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-        }
-        if (x < pbm_image->width_ - 2) {
-          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-        }
-      }
     }
-  }
 
-  free(double_data);
-  return pbm_image;
+    free(double_data);
+    return pbm_image;
 }
 
 /**
@@ -396,47 +398,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-  // Open file for writing
-  FILE *fp = fopen(filename, "wb");
-  if (!fp) {
-    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-    return false;
-  }
+    // Open file for writing
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+        return false;
+    }
 
-  // Write header (magic number, width, height)
-  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-    fclose(fp);
-    return false;
-  }
+    // Write header (magic number, width, height)
+    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+        fclose(fp);
+        return false;
+    }
 
-  // Allocate buffer for encoded pixel data
-  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
-  if (!buffer) {
-    fprintf(stderr, "Error: out of memory\n");
-    fclose(fp);
-    return false;
-  }
+    // Allocate buffer for encoded pixel data
+    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+    uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+    if (!buffer) {
+        fprintf(stderr, "Error: out of memory\n");
+        fclose(fp);
+        return false;
+    }
 
 // Encode pixel data
-#pragma omp parallel for default(none) shared(image, buffer)
-  for (size_t i = 0; i < image->width_ * image->height_; i++) {
-    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-  }
+    #pragma omp parallel for default(none) shared(image, buffer)
+    for (size_t i = 0; i < image->width_ * image->height_; i++) {
+        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+    }
 
-  // Write encoded pixel data to file
-  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-            filename);
+    // Write encoded pixel data to file
+    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+                filename);
+        free(buffer);
+        fclose(fp);
+        return false;
+    }
+
     free(buffer);
     fclose(fp);
-    return false;
-  }
-
-  free(buffer);
-  fclose(fp);
-  return true;
+    return true;
 }
 
 /**
@@ -445,8 +447,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-  free(image->data_);
-  free(image);
+    free(image->data_);
+    free(image);
 }
 
 #endif // NETPBM__PBM_H_

--- a/pbm.h
+++ b/pbm.h
@@ -14,9 +14,7 @@
 
 #include <sys/random.h>
 
-ssize_t MyRandom(void *buf, size_t len) {
-    return getrandom(buf, len, 0);
-}
+ssize_t MyRandom(void *buf, size_t len) { return getrandom(buf, len, 0); }
 
 #else /* not linux */
 
@@ -25,14 +23,14 @@ ssize_t MyRandom(void *buf, size_t len) {
 #include <stdlib.h>
 
 ssize_t MyRandom(void *buf, size_t len) {
-    unsigned char *buffer = (unsigned char *)buf;
-    size_t i;
+  unsigned char *buffer = (unsigned char *)buf;
+  size_t i;
 
-    for (i = 0; i < len; ++i) {
-        buffer[i] = (unsigned char)rand();
-    }
+  for (i = 0; i < len; ++i) {
+    buffer[i] = (unsigned char)rand();
+  }
 
-    return (ssize_t)len;
+  return (ssize_t)len;
 }
 
 #endif
@@ -45,21 +43,21 @@ ssize_t MyRandom(void *buf, size_t len) {
  * @return          A pointer to the PbmImage, or NULL if an error occurred.
  */
 PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
-    // Allocate memory for image data
-    PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
-    if (!image) {
-        fprintf(stderr, "Error: out of memory\n");
-        return NULL;
-    }
-    image->width_ = width;
-    image->height_ = height;
-    image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
-    if (!image->data_) {
-        fprintf(stderr, "Error: out of memory\n");
-        free(image);
-        return NULL;
-    }
-    return image;
+  // Allocate memory for image data
+  PbmImage *image = (PbmImage *)malloc(sizeof(PbmImage));
+  if (!image) {
+    fprintf(stderr, "Error: out of memory\n");
+    return NULL;
+  }
+  image->width_ = width;
+  image->height_ = height;
+  image->data_ = (uint8_t *)malloc(width * height * sizeof(uint8_t));
+  if (!image->data_) {
+    fprintf(stderr, "Error: out of memory\n");
+    free(image);
+    return NULL;
+  }
+  return image;
 }
 
 /**
@@ -69,72 +67,72 @@ PbmImage *AllocatePbm(uint32_t width, uint32_t height) {
  * @return          A pointer to the image data, or NULL if an error occurred.
  */
 PbmImage *ReadPbm(const char *filename) {
-    // Open file for reading
-    FILE *fp = fopen(filename, "rb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s'\n", filename);
-        return NULL;
-    }
+  // Open file for reading
+  FILE *fp = fopen(filename, "rb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s'\n", filename);
+    return NULL;
+  }
 
-    // Read header (magic number, width, and height)
-    char magic[3];
-    uint32_t width;
-    uint32_t height;
-    if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
-               &height) != 3) {
-        fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Make sure the magic number is "P4" (binary PBM format)
-    if (magic[0] != 'P' || magic[1] != '4') {
-        fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Allocate memory for buffer
-    size_t buffer_size = (size_t)((width * height + 7) / 8);
-    uint8_t *buffer = (uint8_t *)malloc(buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return NULL;
-    }
-
-    // Read pixel data into buffer
-    if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return NULL;
-    }
-
-    // Close file
+  // Read header (magic number, width, and height)
+  char magic[3];
+  uint32_t width;
+  uint32_t height;
+  if (fscanf(fp, "%2s%*[ \t\r\n]%u%*[ \t\r\n]%u%*1[ \t\r\n]", magic, &width,
+             &height) != 3) {
+    fprintf(stderr, "Error: invalid header in file '%s'\n", filename);
     fclose(fp);
+    return NULL;
+  }
 
-    // Allocate memory for image data
-    PbmImage *image = AllocatePbm(width, height);
+  // Make sure the magic number is "P4" (binary PBM format)
+  if (magic[0] != 'P' || magic[1] != '4') {
+    fprintf(stderr, "Error: unsupported file format in file '%s'\n", filename);
+    fclose(fp);
+    return NULL;
+  }
 
-    // Decode the pixel data from the buffer
-    #pragma omp parallel for default(none) shared(image, buffer, width, height)
-    for (size_t i = 0; i < width * height; i += 8) {
-        // Read the next byte from the buffer
-        uint8_t byte = buffer[i / 8];
+  // Allocate memory for buffer
+  size_t buffer_size = (size_t)((width * height + 7) / 8);
+  uint8_t *buffer = (uint8_t *)malloc(buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return NULL;
+  }
 
-        // Decode the byte into the image data (loop through the 8 bits)
-        for (size_t j = 0; j < 8; j++) {
-            size_t index = i + j;
-            if (index < width * height) {
-                image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
-            }
-        }
-    }
-
+  // Read pixel data into buffer
+  if (fread(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: failed to read pixel data from file '%s'\n",
+            filename);
     free(buffer);
-    return image;
+    fclose(fp);
+    return NULL;
+  }
+
+  // Close file
+  fclose(fp);
+
+  // Allocate memory for image data
+  PbmImage *image = AllocatePbm(width, height);
+
+// Decode the pixel data from the buffer
+#pragma omp parallel for default(none) shared(image, buffer, width, height)
+  for (size_t i = 0; i < width * height; i += 8) {
+    // Read the next byte from the buffer
+    uint8_t byte = buffer[i / 8];
+
+    // Decode the byte into the image data (loop through the 8 bits)
+    for (size_t j = 0; j < 8; j++) {
+      size_t index = i + j;
+      if (index < width * height) {
+        image->data_[index] = (byte & (1 << (7 - j))) >> (7 - j);
+      }
+    }
+  }
+
+  free(buffer);
+  return image;
 }
 
 /**
@@ -144,12 +142,12 @@ PbmImage *ReadPbm(const char *filename) {
  * @return Normalized image data
  */
 double *NormalizePgm(const PgmImage *image) {
-    double *double_data =
-        (double *)malloc(image->width_ * image->height_ * sizeof(double));
-    #pragma omp parallel for default(none) shared(image, double_data)
-    for (uint32_t i = 0; i < image->height_ * image->width_; i++)
-        double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
-    return double_data;
+  double *double_data =
+      (double *)malloc(image->width_ * image->height_ * sizeof(double));
+#pragma omp parallel for default(none) shared(image, double_data)
+  for (uint32_t i = 0; i < image->height_ * image->width_; i++)
+    double_data[i] = (double)image->data_[i] / PGM_MAX_GRAY_F;
+  return double_data;
 }
 
 /**
@@ -157,9 +155,7 @@ double *NormalizePgm(const PgmImage *image) {
  *
  * @return 128
  */
-uint8_t MiddleThreshold() {
-    return 128;
-}
+uint8_t MiddleThreshold() { return 128; }
 
 /**
  * Threshold function that returns a random value between 0 and 255.
@@ -167,9 +163,9 @@ uint8_t MiddleThreshold() {
  * @return Random value between 0 and 255
  */
 uint8_t RandomThreshold() {
-    uint8_t random;
-    MyRandom(&random, sizeof(uint8_t));
-    return random;
+  uint8_t random;
+  MyRandom(&random, sizeof(uint8_t));
+  return random;
 }
 
 /**
@@ -181,15 +177,15 @@ uint8_t RandomThreshold() {
  * occurred.
  */
 PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Convert pixel data
-    #pragma omp parallel for default(none) shared(image, pbm_image, threshold)
-    for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
-        pbm_image->data_[i] = image->data_[i] < threshold();
+// Convert pixel data
+#pragma omp parallel for default(none) shared(image, pbm_image, threshold)
+  for (uint32_t i = 0; i < pbm_image->width_ * pbm_image->height_; i++)
+    pbm_image->data_[i] = image->data_[i] < threshold();
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -200,55 +196,55 @@ PbmImage *PgmToPbm(const PgmImage *image, ThresholdFn threshold) {
  * occurred.
  */
 PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Atkinson dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Atkinson dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 1 / 8;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 1 / 8;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 1 / 8;
         }
+        double_data[pos + pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 8;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 1 / 8;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 8;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 1 / 8;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 1 / 8;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -259,23 +255,23 @@ PbmImage *PgmToPbmAtkinson(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmBayer(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert using Bayer (Ordered) Dithering
-    #pragma omp parallel for default(none)                                         \
+// Convert using Bayer (Ordered) Dithering
+#pragma omp parallel for default(none)                                         \
     shared(kBayer8X8, pbm_image, double_data) collapse(2)
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
-        }
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      pbm_image->data_[pos] = double_data[pos] < kBayer8X8[x & 7][y & 7];
     }
+  }
 
-    return pbm_image;
+  return pbm_image;
 }
 
 /**
@@ -286,43 +282,43 @@ PbmImage *PgmToPbmBayer(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Floyd-Steinberg dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Floyd-Steinberg dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 16;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 16;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 16;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 16;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 16;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 1 / 16;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -333,61 +329,61 @@ PbmImage *PgmToPbmFloydSteinberg(const PgmImage *image) {
  * occurred.
  */
 PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
-    // Allocate memory for new image data
-    PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
+  // Allocate memory for new image data
+  PbmImage *pbm_image = AllocatePbm(image->width_, image->height_);
 
-    // Normalize pixel data to [0, 1] double values
-    double *double_data = NormalizePgm(image);
+  // Normalize pixel data to [0, 1] double values
+  double *double_data = NormalizePgm(image);
 
-    // Convert pixel data using Jarvis, Judice, and Ninke dithering
-    for (uint32_t y = 0; y < pbm_image->height_; y++) {
-        for (uint32_t x = 0; x < pbm_image->width_; x++) {
-            uint32_t pos = y * pbm_image->width_ + x;
-            double old_pixel = double_data[pos];
-            double new_pixel = round(old_pixel);
+  // Convert pixel data using Jarvis, Judice, and Ninke dithering
+  for (uint32_t y = 0; y < pbm_image->height_; y++) {
+    for (uint32_t x = 0; x < pbm_image->width_; x++) {
+      uint32_t pos = y * pbm_image->width_ + x;
+      double old_pixel = double_data[pos];
+      double new_pixel = round(old_pixel);
 
-            // Invert pixel value (PBM is white 0 and black 1)
-            pbm_image->data_[pos] = new_pixel == 0;
+      // Invert pixel value (PBM is white 0 and black 1)
+      pbm_image->data_[pos] = new_pixel == 0;
 
-            // Calculate error
-            double error = old_pixel - new_pixel;
+      // Calculate error
+      double error = old_pixel - new_pixel;
 
-            // Propagate error
-            if (x < pbm_image->width_ - 1) {
-                double_data[pos + 1] += error * 7 / 48;
-            }
-            if (x < pbm_image->width_ - 2) {
-                double_data[pos + 2] += error * 5 / 48;
-            }
-            if (y < pbm_image->height_ - 1) {
-                if (x > 0) {
-                    double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
-                }
-                double_data[pos + pbm_image->width_] += error * 5 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
-                }
-            }
-            if (y < pbm_image->height_ - 2) {
-                if (x > 0) {
-                    double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
-                }
-                double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
-                if (x < pbm_image->width_ - 1) {
-                    double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
-                }
-                if (x < pbm_image->width_ - 2) {
-                    double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
-                }
-            }
+      // Propagate error
+      if (x < pbm_image->width_ - 1) {
+        double_data[pos + 1] += error * 7 / 48;
+      }
+      if (x < pbm_image->width_ - 2) {
+        double_data[pos + 2] += error * 5 / 48;
+      }
+      if (y < pbm_image->height_ - 1) {
+        if (x > 0) {
+          double_data[pos + pbm_image->width_ - 1] += error * 3 / 48;
         }
+        double_data[pos + pbm_image->width_] += error * 5 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + pbm_image->width_ + 1] += error * 7 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + pbm_image->width_ + 2] += error * 5 / 48;
+        }
+      }
+      if (y < pbm_image->height_ - 2) {
+        if (x > 0) {
+          double_data[pos + 2 * pbm_image->width_ - 1] += error * 1 / 48;
+        }
+        double_data[pos + 2 * pbm_image->width_] += error * 3 / 48;
+        if (x < pbm_image->width_ - 1) {
+          double_data[pos + 2 * pbm_image->width_ + 1] += error * 5 / 48;
+        }
+        if (x < pbm_image->width_ - 2) {
+          double_data[pos + 2 * pbm_image->width_ + 2] += error * 3 / 48;
+        }
+      }
     }
+  }
 
-    free(double_data);
-    return pbm_image;
+  free(double_data);
+  return pbm_image;
 }
 
 /**
@@ -398,47 +394,47 @@ PbmImage *PgmToPbmJarvisJudiceNinke(const PgmImage *image) {
  * @return          True if successful, false otherwise.
  */
 bool WritePbm(const char *filename, const PbmImage *image) {
-    // Open file for writing
-    FILE *fp = fopen(filename, "wb");
-    if (!fp) {
-        fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
-        return false;
-    }
+  // Open file for writing
+  FILE *fp = fopen(filename, "wb");
+  if (!fp) {
+    fprintf(stderr, "Error: could not open file '%s' for writing\n", filename);
+    return false;
+  }
 
-    // Write header (magic number, width, height)
-    if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
-        fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
-        fclose(fp);
-        return false;
-    }
+  // Write header (magic number, width, height)
+  if (fprintf(fp, "P4\n%u\n%u\n", image->width_, image->height_) < 0) {
+    fprintf(stderr, "Error: could not write header to file '%s'\n", filename);
+    fclose(fp);
+    return false;
+  }
 
-    // Allocate buffer for encoded pixel data
-    size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
-    uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
-    if (!buffer) {
-        fprintf(stderr, "Error: out of memory\n");
-        fclose(fp);
-        return false;
-    }
+  // Allocate buffer for encoded pixel data
+  size_t buffer_size = (image->width_ * image->height_ + 7) / 8;
+  uint8_t *buffer = (uint8_t *)calloc(1, buffer_size);
+  if (!buffer) {
+    fprintf(stderr, "Error: out of memory\n");
+    fclose(fp);
+    return false;
+  }
 
-    // Encode pixel data
-    #pragma omp parallel for default(none) shared(image, buffer)
-    for (size_t i = 0; i < image->width_ * image->height_; i++) {
-        buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
-    }
+// Encode pixel data
+#pragma omp parallel for default(none) shared(image, buffer)
+  for (size_t i = 0; i < image->width_ * image->height_; i++) {
+    buffer[i / 8] |= (image->data_[i] << (7 - i % 8));
+  }
 
-    // Write encoded pixel data to file
-    if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
-        fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
-                filename);
-        free(buffer);
-        fclose(fp);
-        return false;
-    }
-
+  // Write encoded pixel data to file
+  if (fwrite(buffer, 1, buffer_size, fp) != buffer_size) {
+    fprintf(stderr, "Error: could not write pixel data to file '%s'\n",
+            filename);
     free(buffer);
     fclose(fp);
-    return true;
+    return false;
+  }
+
+  free(buffer);
+  fclose(fp);
+  return true;
 }
 
 /**
@@ -447,8 +443,8 @@ bool WritePbm(const char *filename, const PbmImage *image) {
  * @param image     Image to free
  */
 void FreePbm(PbmImage *image) {
-    free(image->data_);
-    free(image);
+  free(image->data_);
+  free(image);
 }
 
 #endif // NETPBM__PBM_H_


### PR DESCRIPTION
Randomness is compromised, but I was not able to find a random generator on Windows that is both fast and secure. I tried `CryptGenRandom` from `wincrypt.h` with multiple configurations and ways, but they all took longer than a minute to generate a single image using random dithering. This is why I chose to use just plain old `rand()`.

I also choose to keep the contract of `getrandom`, so no changes had to be made to the functions already using `getrandom`.